### PR TITLE
make pseudonitzchia discoverable through GloBI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+install: 
+  - wget "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/check-dataset.sh" -O check-dataset.sh
+  - chmod +x check-dataset.sh
+
+script: 
+  - ./check-dataset.sh ${TRAVIS_REPO_SLUG}

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ represent EOL taxon IDs. The first column is the EOL taxon ID for the taxon page
 mined. The second column is the EOL taxon ID for the taxon that was found in a text object 
 on the taxon page for the taxon in the first column. There is an implied interaction 
 between the two taxa in each row. The type of interaction is unknown.
+
+Ready for discovery through http://globalbioticinteractions.org .

--- a/associations_all_revised.txt-schema.json
+++ b/associations_all_revised.txt-schema.json
@@ -1,0 +1,19 @@
+{
+    "columns": [
+      {
+        "name": "sourceTaxonId",
+        "datatype": { 
+          "id" : "http://eol.org/schema/taxonID",
+          "base" :"decimal"
+        }
+      }, 
+      {
+        "name": "targetTaxonId",
+        "datatype": { 
+          "id" : "http://eol.org/schema/taxonID",
+          "base" :"decimal"
+        }
+      }
+    ]
+}
+ 

--- a/globi.json
+++ b/globi.json
@@ -1,0 +1,13 @@
+{
+  "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
+  "rdfs:comment": ["inspired by https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/"],
+  "tables": [
+    { "url": "associations_all_revised.txt",
+      "dcterms:bibliographicCitation": "A. Thessen. 2014. Species associations extracted from EOL text data objects via text mining.",
+      "tableSchema": "associations_all_revised.txt-schema.json",
+      "headerRowCount": 0,
+      "interactionTypeId": "http://purl.obolibrary.org/obo/RO_0002437",
+      "interactionTypeName": "interactsWith"
+    }
+  ]
+}

--- a/globi.json
+++ b/globi.json
@@ -6,6 +6,7 @@
       "dcterms:bibliographicCitation": "A. Thessen. 2014. Species associations extracted from EOL text data objects via text mining.",
       "tableSchema": "associations_all_revised.txt-schema.json",
       "headerRowCount": 0,
+      "delimiter": "\t",
       "interactionTypeId": "http://purl.obolibrary.org/obo/RO_0002437",
       "interactionTypeName": "interactsWith"
     }


### PR DESCRIPTION
Until now, GloBI had a static pointer to https://github.com/EOL/pseudonitzchia . With the changes in the pull request, this repository can be automatically discovered. This would (hopefully) make it easier to (re-)move or update the repository resources when so desired. 